### PR TITLE
feature/multi select boundaries 1.0.0

### DIFF
--- a/script.js
+++ b/script.js
@@ -353,16 +353,16 @@ function handleData([
   layersControl
     .addOverlay(indicators, "Indicators")
     .addOverlay(oralHistories, "Oral Histories")
-    .addBaseLayer(zoningBoundary, "Greater Mattapan Zoning Boundary")
-    .addBaseLayer(planningBoundary, "BPDA Planning District Boundary")
-    .addBaseLayer(neighbBoundary, "BDPA Unofficial Neighborhood Boundary")
-    .addBaseLayer(riverStreetBoundary, "River Street Boundary")
-    .addBaseLayer(PLANBoundary, "PLAN Mattapan Boundary")
-    .addBaseLayer(mattapanLineBoundary, "Mattapan Line Boundary")
-    .addBaseLayer(blueHillAveBoundary, "Blue Hill Ave Boundary")
-    .addBaseLayer(mattapanSqBoundary, "Mattapan Square Boundary")
-    .addBaseLayer(cumminsHwyBoundary, "Cummins Highway Boundary")
-    .addBaseLayer(greaterMattapanMergedBoundary, "Greater Mattapan Merged Boundary")
+    .addOverlay(zoningBoundary, "Greater Mattapan Zoning Boundary")
+    .addOverlay(planningBoundary, "BPDA Planning District Boundary")
+    .addOverlay(neighbBoundary, "BDPA Unofficial Neighborhood Boundary")
+    .addOverlay(riverStreetBoundary, "River Street Boundary")
+    .addOverlay(PLANBoundary, "PLAN Mattapan Boundary")
+    .addOverlay(mattapanLineBoundary, "Mattapan Line Boundary")
+    .addOverlay(blueHillAveBoundary, "Blue Hill Ave Boundary")
+    .addOverlay(mattapanSqBoundary, "Mattapan Square Boundary")
+    .addOverlay(cumminsHwyBoundary, "Cummins Highway Boundary")
+    .addOverlay(greaterMattapanMergedBoundary, "Greater Mattapan Merged Boundary")
 
   // Apply correct relative order of layers when adding from control.
   map.on("overlayadd", function () {


### PR DESCRIPTION
Leaflet does not support overlaying multiple boundaries. Because we are using the geojson type to create the existing boundaries we were able to convert these entities to overlays. Leaflet supports display multiple overlays at one time and will update the controls to use checkboxes.

Supporting documentation
https://leafletjs.com/examples/geojson/
https://leafletjs.com/examples/layers-control/