### PR TITLE
feature/pop-up-overlay-behavior-consolidation-1.0.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,11 +100,11 @@
         </div>
       </div>
     </script>
-  
-    <script id="aemp-infowindow-template" type="x-tmpl-mustache">
+    
+    <!--Small pop up overlay which is rendered when indicators are initally clicked-->
+    <script id="aemp-infowindow-small-template" type="x-tmpl-mustache">
       <div class="aemp-infowindow">
         <a class="aemp-infowindow-close" href="#close" onClick="closeInfo()">×</a>
-  
         <div>
           <p>
             <strong>Title: </strong>{{title}}
@@ -127,8 +127,36 @@
       </div>
     </script>
 
-    <script id="aemp-oralhistory-infowindow-template" type="x-tmpl-mustache">
-      <div class="oral-history-infowindow">
+    <!--Large pop up overlay which is rendered when more data is requried-->
+    <script id="aemp-infowindow-large-template" type="x-tmpl-mustache">
+      <div class="aemp-infowindow aemp-modal-container">
+        <a class="aemp-infowindow-close" href="#close" onClick="closeInfo()">×</a>
+        <div>
+          <p>
+            <strong>Title: </strong>{{title}}
+          </p>
+        </div>
+        <div>
+          <p><strong>Description:</strong></p>
+          <p>{{Description}}</p>
+        </div>
+        {{#img_link}}
+        <div>
+            <img src="{{img_link}}" width="100%">
+        </div>
+        {{/img_link}}
+        {{#link}}
+        <div>
+          <p><a target="_blank" href="{{link}}" rel="noopener noreferrer">View more info.</a></p>
+        </div>
+        {{/link}}
+      </div>
+    </script>
+
+    <!--Small pop up overlay which is rendered when oral history indicators require more information to be displayed -->
+    <script id="aemp-oralhistory-infowindow-large-template" type="x-tmpl-mustache">
+      <div class="oral-history-infowindow aemp-modal-container">
+        <div class="aemp-modal-content">
         <a class="aemp-infowindow-close" href="#close" onClick="closeInfo()">×</a>
         <div>
           <p class="infowindow-title">
@@ -160,6 +188,46 @@
           <p><a target="_blank" href="{{link}}" rel="noopener noreferrer">Listen here.</a></p>
         </div>
         {{/link}}
+        </div>
+      </div>
+    </script>
+
+    <!--Small pop up overlay which is rendered when oral history markers are initally clicked-->
+    <script id="aemp-oralhistory-infowindow-small-template" type="x-tmpl-mustache">
+      <div class="oral-history-infowindow">
+        <div class="aemp-modal-content aemp-infowindow">
+        <a class="aemp-infowindow-close" href="#close" onClick="closeInfo()">×</a>
+        <div>
+          <p class="infowindow-title">
+            <strong>{{headline}}</strong>
+          </p>
+        </div>
+        <div>
+          <p>
+            <strong>Interviewee: {{interviewee}}</strong>{{}}
+          </p>
+        </div>
+        <div>
+          <p><strong>Location:</strong></p>
+          <p>{{location}}</p>
+        </div>
+        <div class="audio-controls">
+          <audio controls>
+            <source src={{cloudinary_url}} type="audio/mpeg">
+            Your browser does not support the audio tag.
+          </audio>
+        </div>
+        {{#img_link}}
+        <div>
+            <img src="{{img_link}}" width="50%">
+        </div>
+        {{/img_link}}
+        {{#link}}
+        <div>
+          <p><a target="_blank" href="{{link}}" rel="noopener noreferrer">Listen here.</a></p>
+        </div>
+        {{/link}}
+        </div>
       </div>
     </script>
 

--- a/script.js
+++ b/script.js
@@ -157,12 +157,12 @@ const layersControl = L.control
 // Get the popup & infowindow templates from the HTML.
 // We can do this here because the template will never change.
 const popupTemplate = document.querySelector(".popup-template").innerHTML;
-const infowindowTemplate = document.getElementById("aemp-infowindow-template")
-  .innerHTML;
+const infowindowTemplate = document.getElementById("aemp-infowindow-small-template").innerHTML;
+const infowindowTemplateLarge = document.getElementById("aemp-infowindow-large-template").innerHTML;
 
-const oralHistoryInfowindowTemplate = document.getElementById(
-  "aemp-oralhistory-infowindow-template"
-).innerHTML;
+
+const oralHistoryInfowindowTemplate = document.getElementById("aemp-oralhistory-infowindow-small-template").innerHTML;
+const oralHistoryInfowindowTemplateLarge = document.getElementById("aemp-oralhistory-infowindow-large-template").innerHTML;
 
 // Add base layer
 L.tileLayer(
@@ -398,13 +398,19 @@ if (type === 'developments') {
 
     // Render the template with all of the properties. Mustache ignores properties
     // that aren't used in the template, so this is fine.
-    
+    // 
     const renderedInfo = Mustache.render(
       infowindowTemplate,
       layer.feature.properties
     );
 
+    // large overlay
+     /*document.getElementById(
+      "aemp-infowindow-container"
+    ).innerHTML = renderedInfo;*/
+
     return renderedInfo;
+
   }, {
     maxWidth: 300,
     className: 'aemp-infowindow-container'
@@ -450,11 +456,16 @@ function handleOralHistoriesLayer(geoJson) {
       oralHistoryInfowindowTemplate,
       layer.feature.properties
     );
-    document.getElementById(
-      "aemp-infowindow-container"
-    ).innerHTML = renderedInfo;
 
-    return renderedInfo
+    // large overlay
+    /*document.getElementById(
+      "aemp-infowindow-container"
+    ).innerHTML = renderedInfo;*/
+
+    return renderedInfo;
+  }, {
+    maxWidth: 400,
+    className: 'aemp-infowindow-container'
   });
 
   map.addLayer(oralHistoryLayerMarkers);

--- a/script.js
+++ b/script.js
@@ -398,7 +398,6 @@ if (type === 'developments') {
 
     // Render the template with all of the properties. Mustache ignores properties
     // that aren't used in the template, so this is fine.
-    // 
     const renderedInfo = Mustache.render(
       infowindowTemplate,
       layer.feature.properties

--- a/styles.css
+++ b/styles.css
@@ -195,15 +195,11 @@ a:hover {
   border: 2px solid rgb(190, 188, 188);
   border-radius: 5px;
   font-size: 1.5rem;
-  background: white;
-
   top: 35px;
   position: relative;
-  width: 265px;
   margin: 10px 10px 0 0;
   max-height: 95%;
   overflow-y: auto;
-  /* padding: 15px; */
   background: white;
   box-shadow: 0 3px 14px rgba(0, 0, 0, 0.1);
 }
@@ -214,28 +210,29 @@ a:hover {
   box-shadow: 0 3px 14px rgba(0, 0, 0, 0.4);
 }
 
-.oral-history-infowindow {
+.aemp-modal-container {
   padding: 5px 10px;
-  border: 2px solid rgb(190, 188, 188);
-  border-radius: 5px;
-  font-size: 1.5rem;
-  background: white;
-
-  position: absolute;
-  right: 0;
-  top: 305px;
-  width: 325px;
-  margin: 10px 10px 0 0;
-  max-height: 95%;
-  overflow-y: auto;
-  /* padding: 15px; */
-  background: white;
-  box-shadow: 0 3px 14px rgba(0, 0, 0, 0.1);
+    border: 2px solid rgb(190, 188, 188);
+    border-radius: 5px;
+    font-size: 1.5rem;
+    background: white;
+    position: absolute;
+    right: 0;
+    width: 50%;
+    margin: 10px 0 0 -25%;
+    max-height: 95%;
+    overflow-y: auto;
+    background: white;
+    box-shadow: 0 3px 14px rgb(0 0 0 / 10%);
+    left: 50%;
+    bottom: 15%;
+    top: 15%;
+    z-index: 10000;
 }
 
-.leaflet-popup-content .oral-history-infowindow {
+/*.leaflet-popup-content .oral-history-infowindow {
   display: none;
-}
+}*/
 
 .leaflet-popup-tip-container {
   display: none;
@@ -261,4 +258,8 @@ a:hover {
     width: 100%;
     height: 50%;
   }
+}
+
+.audio-controls{
+  text-align: center;
 }


### PR DESCRIPTION
Consolidated the click behavior for indicators and oral history icons. 

What is left
1. adding logic and/or updating data to allow longer descriptions to display a "show more" link
2. Adding logic to support displaying the larger modal window is a user selects to "show more"

Apologies for all the commented out code!

<img width="1421" alt="Screen Shot 2021-06-16 at 9 14 39 AM" src="https://user-images.githubusercontent.com/5722667/122225968-8574e400-ce83-11eb-86d7-aefdbfd0306e.png">
<img width="1418" alt="Screen Shot 2021-06-16 at 9 14 24 AM" src="https://user-images.githubusercontent.com/5722667/122226057-9887b400-ce83-11eb-8314-03a942d85a08.png">
